### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: Fullstack CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Shankar0919/fullstack-monorepo/security/code-scanning/1](https://github.com/Shankar0919/fullstack-monorepo/security/code-scanning/1)

The best way to fix this problem is to explicitly add a `permissions` block to the workflow file, either at the root (recommended if all jobs can use the same reduced permissions) or under the individual job. In this case, since there is only one job and none of its steps appear to require anything more than reading repository contents, adding `permissions: contents: read` at the root will ensure the GITHUB_TOKEN has minimal required privileges, complying with security best practices.

The specific edit required is to add the following lines after the `name` line but before the `on:` block (i.e., between line 1 and line 3):

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
